### PR TITLE
Caught StateError when orElse() is null

### DIFF
--- a/lib/models/routeEvent.dart
+++ b/lib/models/routeEvent.dart
@@ -10,9 +10,15 @@ class RouteEvent {
   RouteEvent.fromJson(Map<String, dynamic> json) {
     if (json['eventType'] is int)
       eventType = MapBoxEvent.values[json['eventType']];
-    else
-      eventType = MapBoxEvent.values
-          .firstWhere((e) => e.toString().split(".").last == json['eventType']);
+    else {
+      try {
+        eventType = MapBoxEvent.values.firstWhere(
+            (e) => e.toString().split(".").last == json['eventType']);
+      } on StateError {
+        //When the list is empty or eventType not found (Bad State: No Element)
+      } catch (e) {}
+    }
+
     var dataJson = json['data'];
     if (eventType == MapBoxEvent.progress_change) {
       data = RouteProgressEvent.fromJson(dataJson);


### PR DESCRIPTION
MapBoxEvent.values.firstWhere() throws a StateError when the search value is not in the list. This happens multiple times during a navigation. I was not sure how to implement the orElse and what to return so I  just decided to catch the StateError. 

Screenshot: 
![crash](https://user-images.githubusercontent.com/50015284/126898308-20656997-b2c9-4ba1-a86a-dab1cd62107a.png)
