### PR TITLE
exception on android 12+  Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent. fixed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,7 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.work:work-runtime-ktx:2.7.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.mapbox.navigation:android:2.2.1"
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application>
-        <activity android:name="com.eopeter.flutter_mapbox_navigation.activity.NavigationActivity" />
+        <activity android:name="com.eopeter.flutter_mapbox_navigation.activity.NavigationActivity" android:export="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
hi tnx a lot for your package i think i have solved this exception thrown on android 12 devices 

additionally there is this kotlin code snippet but i dont have kotling knowledge necessary for implementing it but adding workmanager dependency and enabling activity export solved the problem for me.

```
val updatedPendingIntent = PendingIntent.getActivity(
   applicationContext,
   NOTIFICATION_REQUEST_CODE,
   updatedIntent,
   PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT // setting the mutability flag 
)
```

for mutable flag 

```
val updatedPendingIntent = PendingIntent.getActivity(
   applicationContext,
   NOTIFICATION_REQUEST_CODE,
   updatedIntent,
   PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT // setting the mutability flag 
)
```