### PR TITLE
updated embedded nav android to use drop-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ migrate_working_dir/
 build/
 
 /example/android/app/src/main/res/values/mapbox_access_token.xml
+example/android/app/src/main/res/values/strings.xml

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ android.enableJetifier=true
 MAPBOX_DOWNLOADS_TOKEN=sk.epe9nE9peAcmwNzKVNqSbFfp2794YtnNepe9nE9peAcmwNzKVNqSbFfp2794YtnN.-HrbMMQmLdHwYb8r
 ```
 
+4. Update `MainActivity.kt` to extends `FlutterFragmentActivity` vs `FlutterActivity`. Otherwise you'll get `Caused by: java.lang.IllegalStateException: Please ensure that the hosting Context is a valid ViewModelStoreOwner`.
+```kotlin
+//import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
+
+class MainActivity: FlutterFragmentActivity() {
+}
+```
+
+5. Add `implementation platform("org.jetbrains.kotlin:kotlin-bom:1.8.0")` to `android/app/build.gradle`
+
 ## Usage
 
 #### Set Default Route Options (Optional)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.eopeter.flutter_mapbox_navigation'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.7.10'
     ext.android_gradle_version = '7.4.2'
     repositories {
         google()
@@ -87,9 +87,9 @@ android {
 
 dependencies {
     // Mapbox Navigation SDK
-    implementation "com.mapbox.navigation:copilot:2.10.1"
-    implementation "com.mapbox.navigation:ui-app:2.10.1"
-    implementation "com.mapbox.navigation:ui-dropin:2.10.1"
+    implementation "com.mapbox.navigation:copilot:2.10.4"
+    implementation "com.mapbox.navigation:ui-app:2.10.4"
+    implementation "com.mapbox.navigation:ui-dropin:2.10.4"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.code.gson:gson:2.8.9'

--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/activity/NavigationActivity.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/activity/NavigationActivity.kt
@@ -52,15 +52,15 @@ class NavigationActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         accessToken =
-            PluginUtilities.getResourceFromContext(this.applicationContext, "mapbox_access_token")
+                PluginUtilities.getResourceFromContext(this.applicationContext, "mapbox_access_token")
 
         val navigationOptions = NavigationOptions.Builder(this.applicationContext)
-            .accessToken(accessToken)
-            .build()
+                .accessToken(accessToken)
+                .build()
 
         MapboxNavigationApp
-            .setup(navigationOptions)
-            .attach(this)
+                .setup(navigationOptions)
+                .attach(this)
 
         if (FlutterMapboxNavigationPlugin.allowsClickToSetDestination) {
             binding.navigationView.registerMapObserver(onMapLongClick)
@@ -94,13 +94,13 @@ class NavigationActivity : AppCompatActivity() {
         }
 
         registerReceiver(
-            finishBroadcastReceiver,
-            IntentFilter(NavigationLauncher.KEY_STOP_NAVIGATION)
+                finishBroadcastReceiver,
+                IntentFilter(NavigationLauncher.KEY_STOP_NAVIGATION)
         )
 
         registerReceiver(
-            addWayPointsBroadcastReceiver,
-            IntentFilter(NavigationLauncher.KEY_ADD_WAYPOINTS)
+                addWayPointsBroadcastReceiver,
+                IntentFilter(NavigationLauncher.KEY_ADD_WAYPOINTS)
         )
 
         val p = intent.getSerializableExtra("waypoints") as? MutableList<Waypoint>
@@ -136,38 +136,38 @@ class NavigationActivity : AppCompatActivity() {
     private fun requestRoutes(waypointSet: WaypointSet) {
         sendEvent(MapBoxEvents.ROUTE_BUILDING)
         MapboxNavigationApp.current()!!.requestRoutes(
-            routeOptions = RouteOptions
-                .builder()
-                .applyDefaultNavigationOptions()
-                .applyLanguageAndVoiceUnitOptions(this)
-                .coordinatesList(waypointSet.coordinatesList())
-                .waypointIndicesList(waypointSet.waypointsIndices())
-                .waypointNamesList(waypointSet.waypointsNames())
-                .language(FlutterMapboxNavigationPlugin.navigationLanguage)
-                .alternatives(FlutterMapboxNavigationPlugin.showAlternateRoutes)
-                .build(),
-            callback = object : NavigationRouterCallback {
-                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
-                    sendEvent(MapBoxEvents.ROUTE_BUILD_CANCELLED)
-                }
-
-                override fun onFailure(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
-                    sendEvent(MapBoxEvents.ROUTE_BUILD_FAILED)
-                }
-
-                override fun onRoutesReady(
-                    routes: List<NavigationRoute>,
-                    routerOrigin: RouterOrigin
-                ) {
-                    sendEvent(MapBoxEvents.ROUTE_BUILT, Gson().toJson(routes))
-                    if (routes.isEmpty()) {
-                        sendEvent(MapBoxEvents.ROUTE_BUILD_NO_ROUTES_FOUND)
-                        return
+                routeOptions = RouteOptions
+                        .builder()
+                        .applyDefaultNavigationOptions()
+                        .applyLanguageAndVoiceUnitOptions(this)
+                        .coordinatesList(waypointSet.coordinatesList())
+                        .waypointIndicesList(waypointSet.waypointsIndices())
+                        .waypointNamesList(waypointSet.waypointsNames())
+                        .language(FlutterMapboxNavigationPlugin.navigationLanguage)
+                        .alternatives(FlutterMapboxNavigationPlugin.showAlternateRoutes)
+                        .build(),
+                callback = object : NavigationRouterCallback {
+                    override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
+                        sendEvent(MapBoxEvents.ROUTE_BUILD_CANCELLED)
                     }
-                    binding.navigationView.api.routeReplayEnabled(FlutterMapboxNavigationPlugin.simulateRoute)
-                    binding.navigationView.api.startActiveGuidance(routes)
+
+                    override fun onFailure(reasons: List<RouterFailure>, routeOptions: RouteOptions) {
+                        sendEvent(MapBoxEvents.ROUTE_BUILD_FAILED)
+                    }
+
+                    override fun onRoutesReady(
+                            routes: List<NavigationRoute>,
+                            routerOrigin: RouterOrigin
+                    ) {
+                        sendEvent(MapBoxEvents.ROUTE_BUILT, Gson().toJson(routes.map { it.directionsRoute }))
+                        if (routes.isEmpty()) {
+                            sendEvent(MapBoxEvents.ROUTE_BUILD_NO_ROUTES_FOUND)
+                            return
+                        }
+                        binding.navigationView.api.routeReplayEnabled(FlutterMapboxNavigationPlugin.simulateRoute)
+                        binding.navigationView.api.startActiveGuidance(routes)
+                    }
                 }
-            }
         )
     }
 
@@ -199,36 +199,36 @@ class NavigationActivity : AppCompatActivity() {
         // that make sure the route request is optimized
         // to allow for support of all of the Navigation SDK features
         MapboxNavigationApp.current()!!.requestRoutes(
-            routeOptions = RouteOptions
-                .builder()
-                .applyDefaultNavigationOptions()
-                .applyLanguageAndVoiceUnitOptions(this)
-                .coordinatesList(addedWaypoints.coordinatesList())
-                .waypointIndicesList(addedWaypoints.waypointsIndices())
-                .waypointNamesList(addedWaypoints.waypointsNames())
-                .alternatives(true)
-                .build(),
-            callback = object : NavigationRouterCallback {
-                override fun onRoutesReady(
-                    routes: List<NavigationRoute>,
-                    routerOrigin: RouterOrigin
-                ) {
-                    sendEvent(MapBoxEvents.ROUTE_BUILT, Gson().toJson(routes))
-                    binding.navigationView.api.routeReplayEnabled(true)
-                    binding.navigationView.api.startActiveGuidance(routes)
-                }
+                routeOptions = RouteOptions
+                        .builder()
+                        .applyDefaultNavigationOptions()
+                        .applyLanguageAndVoiceUnitOptions(this)
+                        .coordinatesList(addedWaypoints.coordinatesList())
+                        .waypointIndicesList(addedWaypoints.waypointsIndices())
+                        .waypointNamesList(addedWaypoints.waypointsNames())
+                        .alternatives(true)
+                        .build(),
+                callback = object : NavigationRouterCallback {
+                    override fun onRoutesReady(
+                            routes: List<NavigationRoute>,
+                            routerOrigin: RouterOrigin
+                    ) {
+                        sendEvent(MapBoxEvents.ROUTE_BUILT, Gson().toJson(routes))
+                        binding.navigationView.api.routeReplayEnabled(true)
+                        binding.navigationView.api.startActiveGuidance(routes)
+                    }
 
-                override fun onFailure(
-                    reasons: List<RouterFailure>,
-                    routeOptions: RouteOptions
-                ) {
-                    sendEvent(MapBoxEvents.ROUTE_BUILD_FAILED)
-                }
+                    override fun onFailure(
+                            reasons: List<RouterFailure>,
+                            routeOptions: RouteOptions
+                    ) {
+                        sendEvent(MapBoxEvents.ROUTE_BUILD_FAILED)
+                    }
 
-                override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
-                    sendEvent(MapBoxEvents.ROUTE_BUILD_CANCELLED)
+                    override fun onCanceled(routeOptions: RouteOptions, routerOrigin: RouterOrigin) {
+                        sendEvent(MapBoxEvents.ROUTE_BUILD_CANCELLED)
+                    }
                 }
-            }
         )
     }
 

--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/factory/EmbeddedNavigationViewFactory.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/factory/EmbeddedNavigationViewFactory.kt
@@ -17,23 +17,28 @@ import io.flutter.plugin.platform.PlatformView
 import io.flutter.plugin.platform.PlatformViewFactory
 
 class EmbeddedNavigationViewFactory(
-    private val messenger: BinaryMessenger,
-    private val activity: Activity
+        private val messenger: BinaryMessenger,
+        private val activity: Activity
 ) : PlatformViewFactory(StandardMessageCodec.INSTANCE) {
     override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+
         val inflater = LayoutInflater.from(context)
         val binding = NavigationActivityBinding.inflate(inflater)
         val accessToken = PluginUtilities.getResourceFromContext(context, "mapbox_access_token")
         val view = EmbeddedNavigationMapView(
-            context,
-            activity,
-            binding,
-            messenger,
-            viewId,
-            args,
-            accessToken
+                context,
+                activity,
+                binding,
+                messenger,
+                viewId,
+                args,
+                accessToken
         )
+
+        view.initialize()
+
         activity.setTheme(R.style.Theme_AppCompat_NoActionBar)
+
         return view
     }
 }

--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/models/views/EmbeddedNavigationMapView.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/models/views/EmbeddedNavigationMapView.kt
@@ -10,16 +10,16 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.platform.PlatformView
-
+import eopeter.flutter_mapbox_navigation.databinding.ComponentsNavigationActivityBinding
 
 class EmbeddedNavigationMapView(
-    context: Context,
-    activity: Activity,
-    binding: NavigationActivityBinding,
-    binaryMessenger: BinaryMessenger,
-    vId: Int,
-    args: Any?,
-    accessToken: String
+        context: Context,
+        activity: Activity,
+        binding: NavigationActivityBinding,
+        binaryMessenger: BinaryMessenger,
+        vId: Int,
+        args: Any?,
+        accessToken: String
 ) : PlatformView, TurnByTurn(context, activity, binding, accessToken) {
     private val viewId: Int = vId
     private val messenger: BinaryMessenger = binaryMessenger
@@ -32,6 +32,9 @@ class EmbeddedNavigationMapView(
 
     override fun onFlutterViewAttached(flutterView: View) {
         super.onFlutterViewAttached(flutterView)
+    }
+
+    open fun initialize() {
         initFlutterChannelHandlers()
         initNavigation()
     }
@@ -43,7 +46,5 @@ class EmbeddedNavigationMapView(
 
     override fun dispose() {
         unregisterObservers();
-        onDestroy();
     }
-
 }

--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/utilities/PluginUtilities.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/utilities/PluginUtilities.kt
@@ -10,6 +10,8 @@ import com.eopeter.flutter_mapbox_navigation.FlutterMapboxNavigationPlugin
 import com.eopeter.flutter_mapbox_navigation.models.MapBoxEvents
 import com.eopeter.flutter_mapbox_navigation.models.MapBoxRouteProgressEvent
 import com.google.gson.Gson
+import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.navigation.base.route.NavigationRoute
 import io.flutter.plugin.common.MethodCall
 import java.io.ByteArrayInputStream
 import java.io.InputStream
@@ -26,10 +28,10 @@ class PluginUtilities {
             val stringRes = context.resources.getIdentifier(resName, "string", context.packageName)
             if (stringRes == 0) {
                 throw IllegalArgumentException(
-                    String.format(
-                        "The 'R.string.%s' value it's not defined in your project's resources file.",
-                        resName
-                    )
+                        String.format(
+                                "The 'R.string.%s' value it's not defined in your project's resources file.",
+                                resName
+                        )
                 )
             }
             return context.getString(stringRes)
@@ -46,13 +48,13 @@ class PluginUtilities {
 
         fun sendEvent(event: MapBoxEvents, data: String = "") {
             val jsonString =
-                if (MapBoxEvents.MILESTONE_EVENT == event || event == MapBoxEvents.USER_OFF_ROUTE) "{" +
-                        "  \"eventType\": \"${event.value}\"," +
-                        "  \"data\": $data" +
-                        "}" else "{" +
-                        "  \"eventType\": \"${event.value}\"," +
-                        "  \"data\": \"$data\"" +
-                        "}";
+                    if (MapBoxEvents.MILESTONE_EVENT == event || event == MapBoxEvents.USER_OFF_ROUTE || event == MapBoxEvents.ROUTE_BUILT) "{" +
+                            "  \"eventType\": \"${event.value}\"," +
+                            "  \"data\": $data" +
+                            "}" else "{" +
+                            "  \"eventType\": \"${event.value}\"," +
+                            "  \"data\": \"$data\"" +
+                            "}";
             FlutterMapboxNavigationPlugin.eventSink?.success(jsonString)
         }
 
@@ -119,7 +121,7 @@ class PluginUtilities {
 
         fun isNetworkAvailable(context: Context): Boolean {
             val connectivityManager =
-                context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                    context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 val nw = connectivityManager.activeNetwork ?: return false
                 val actNw = connectivityManager.getNetworkCapabilities(nw) ?: return false
@@ -139,9 +141,9 @@ class PluginUtilities {
         }
 
         fun <T : Serializable?> getSerializable(
-            activity: Activity,
-            name: String,
-            clazz: Class<T>
+                activity: Activity,
+                name: String,
+                clazz: Class<T>
         ): T {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
                 activity.intent.getSerializableExtra(name, clazz)!!

--- a/android/src/main/res/layout/navigation_activity.xml
+++ b/android/src/main/res/layout/navigation_activity.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+app:accessToken can be set to anything other than @string/... as we will
+read from @string/mapbox_access_token later
+ -->
 <com.mapbox.navigation.dropin.NavigationView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/navigationView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:accessToken="@string/mapbox_access_token"
+    app:accessToken="this-can-be-skip-since-we-set-it-later"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 </com.mapbox.navigation.dropin.NavigationView>

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -73,4 +73,5 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation platform("org.jetbrains.kotlin:kotlin-bom:1.8.0")
 }

--- a/example/android/app/src/main/kotlin/com/eopeter/flutter_mapbox_navigation_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/eopeter/flutter_mapbox_navigation_example/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.eopeter.flutter_mapbox_navigation_example
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity() {
+class MainActivity: FlutterFragmentActivity() {
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.7.10'
     ext.android_gradle_version = '7.4.2'
     repositories {
         google()
@@ -27,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -91,10 +91,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -107,10 +107,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -123,18 +123,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -192,10 +192,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -205,5 +205,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.19.4 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.5.0"

--- a/lib/src/embedded/view.dart
+++ b/lib/src/embedded/view.dart
@@ -51,7 +51,7 @@ class MapBoxNavigationView extends StatelessWidget {
           );
         },
         onCreatePlatformView: (params) {
-          return PlatformViewsService.initSurfaceAndroidView(
+          return PlatformViewsService.initExpensiveAndroidView(
             id: params.id,
             viewType: viewType,
             layoutDirection: TextDirection.ltr,
@@ -62,6 +62,7 @@ class MapBoxNavigationView extends StatelessWidget {
             },
           )
             ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+            ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
             ..create();
         },
       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
@@ -76,10 +76,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -92,10 +92,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -108,18 +108,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   plugin_platform_interface:
     dependency: "direct main"
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -190,5 +190,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.19.4 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.5.0"


### PR DESCRIPTION
1. Rollback kotlin version to 1.7 vs 1.8, version 1.8 caused a bunch of conflicts as other plugins does not support version 1.8
2. Updated gradle to 7.6
3. Updated emdedded version of android to use drop-in
4. `route_built` even now even https://docs.mapbox.com/api/navigation/directions/#route-object as part of `data`. You can use this to customize UI.

Embedded navigation on Android now works.