### PR TITLE
Feature/navigation cancelled finished

### DIFF
--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/Utility.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/Utility.kt
@@ -4,8 +4,11 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.content.Context
+import android.content.res.Resources
 import android.location.Location
 import android.os.Bundle
+import android.transition.Scene
+import android.util.DisplayMetrics
 import androidx.lifecycle.LifecycleOwner
 import com.eopeter.flutter_mapbox_navigation.models.MapBoxEvents
 import com.eopeter.flutter_mapbox_navigation.models.MapBoxRouteProgressEvent
@@ -34,6 +37,17 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.util.*
 import android.util.Log
+import android.view.Gravity
+import android.view.ViewGroup
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
+import com.mapbox.navigation.dropin.R
+import androidx.core.view.setPadding
+import com.eopeter.flutter_mapbox_navigation.utilities.CustomInfoPanelEndNavButtonBinder
+import com.mapbox.navigation.dropin.internal.extensions.updateMargins
 
 open class TurnByTurn(ctx: Context, act: Activity, bind: NavigationActivityBinding, accessToken: String):  MethodChannel.MethodCallHandler, EventChannel.StreamHandler,
         Application.ActivityLifecycleCallbacks {
@@ -126,6 +140,9 @@ open class TurnByTurn(ctx: Context, act: Activity, bind: NavigationActivityBindi
                         PluginUtilities.sendEvent(MapBoxEvents.ROUTE_BUILT, Gson().toJson(routes.map { it.directionsRoute.toJson() }))
                         binding.navigationView.api.routeReplayEnabled(simulateRoute)
                         binding.navigationView.api.startRoutePreview(routes)
+                        binding.navigationView.customizeViewBinders {
+                            infoPanelEndNavigationButtonBinder = CustomInfoPanelEndNavButtonBinder(MapboxNavigationApp.current()!!)
+                        }
                     }
 
                     override fun onFailure(

--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/activity/NavigationActivity.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/activity/NavigationActivity.kt
@@ -9,6 +9,7 @@ import com.eopeter.flutter_mapbox_navigation.models.MapBoxEvents
 import com.eopeter.flutter_mapbox_navigation.models.MapBoxRouteProgressEvent
 import com.eopeter.flutter_mapbox_navigation.models.Waypoint
 import com.eopeter.flutter_mapbox_navigation.models.WaypointSet
+import com.eopeter.flutter_mapbox_navigation.utilities.CustomInfoPanelEndNavButtonBinder
 import com.eopeter.flutter_mapbox_navigation.utilities.PluginUtilities
 import com.eopeter.flutter_mapbox_navigation.utilities.PluginUtilities.Companion.sendEvent
 import com.mapbox.api.directions.v5.models.DirectionsRoute
@@ -26,14 +27,13 @@ import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.arrival.ArrivalObserver
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
-import com.mapbox.navigation.core.trip.session.LocationMatcherResult
-import com.mapbox.navigation.core.trip.session.LocationObserver
-import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.dropin.map.MapViewObserver
 import com.mapbox.navigation.utils.internal.ifNonNull
 import eopeter.flutter_mapbox_navigation.R
 import eopeter.flutter_mapbox_navigation.databinding.NavigationActivityBinding
 import com.google.gson.Gson
+import com.mapbox.navigation.core.trip.session.*
+import com.mapbox.navigation.dropin.navigationview.NavigationViewListener
 
 class NavigationActivity : AppCompatActivity() {
 
@@ -67,6 +67,9 @@ class NavigationActivity : AppCompatActivity() {
             binding.navigationView.customizeViewOptions {
                 enableMapLongClickIntercept = false
             }
+        }
+        binding.navigationView.customizeViewBinders {
+            infoPanelEndNavigationButtonBinder = CustomInfoPanelEndNavButtonBinder(MapboxNavigationApp.current()!!)
         }
 
         MapboxNavigationApp.current()?.registerLocationObserver(locationObserver)

--- a/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/utilities/CustomInfoPanelEndNavButtonBinder.kt
+++ b/android/src/main/kotlin/com/eopeter/flutter_mapbox_navigation/utilities/CustomInfoPanelEndNavButtonBinder.kt
@@ -1,0 +1,39 @@
+package com.eopeter.flutter_mapbox_navigation.utilities
+
+import android.view.ViewGroup
+import com.eopeter.flutter_mapbox_navigation.models.MapBoxEvents
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.internal.extensions.updateMargins
+import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
+
+class CustomInfoPanelEndNavButtonBinder(
+    private val nav: MapboxNavigation
+) : UIBinder {
+    override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
+        val button = MapboxExtendableButton(
+            viewGroup.context,
+            null,
+            R.style.DropInStyleExitButton
+        )
+        button.iconImage.setImageResource(R.drawable.mapbox_ic_stop_navigation)
+        viewGroup.removeAllViews()
+        viewGroup.addView(button)
+        button.updateMargins(
+            right = button.resources.getDimensionPixelSize(R.dimen.mapbox_infoPanel_paddingEnd)
+        )
+
+        return object : UIComponent() {
+            override fun onAttached(mapboxNavigation: MapboxNavigation) {
+                super.onAttached(mapboxNavigation)
+                button.setOnClickListener {
+                    nav.stopTripSession()
+                    PluginUtilities.sendEvent(MapBoxEvents.NAVIGATION_CANCELLED)
+                }
+            }
+        }
+    }
+}

--- a/ios/Classes/NavigationFactory.swift
+++ b/ios/Classes/NavigationFactory.swift
@@ -384,7 +384,7 @@ extension NavigationFactory : NavigationViewControllerDelegate {
 
             _eventSink!(progressEventJson)
 
-            if(progress.isFinalLeg && progress.currentLegProgress.userHasArrivedAtWaypoint)
+            if(progress.isFinalLeg && progress.currentLegProgress.userHasArrivedAtWaypoint && !_showEndOfRouteFeedback)
             {
                 _eventSink = nil
             }
@@ -414,5 +414,22 @@ extension NavigationFactory : NavigationViewControllerDelegate {
 
     public func navigationViewController(_ navigationViewController: NavigationViewController, shouldRerouteFrom location: CLLocation) -> Bool {
         return _shouldReRoute
+    }
+    
+    public func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitArrivalFeedback feedback: EndOfRouteFeedback) {
+        
+        if(_eventSink != nil)
+        {
+            let jsonEncoder = JSONEncoder()
+
+            let localFeedback = Feedback(rating: feedback.rating, comment: feedback.comment)
+            let feedbackJsonData = try! jsonEncoder.encode(localFeedback)
+            let feedbackJson = String(data: feedbackJsonData, encoding: String.Encoding.ascii)
+
+            sendEvent(eventType: MapBoxEventType.navigation_finished, data: feedbackJson ?? "")
+            
+            _eventSink = nil
+
+        }
     }
 }

--- a/ios/Classes/models/EventType.swift
+++ b/ios/Classes/models/EventType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum MapBoxEventType: Int, Codable
+enum MapBoxEventType: String, Codable
 {
     case map_ready
     case route_building

--- a/ios/Classes/models/Feedback.swift
+++ b/ios/Classes/models/Feedback.swift
@@ -1,0 +1,19 @@
+//
+//  Feedback.swift
+//  flutter_mapbox_navigation
+//
+//  Created by Marco Galetta on 20/05/23.
+//
+
+import Foundation
+
+public class Feedback : Codable
+{
+    let rating: Int?
+    let comment: String?
+
+    init(rating: Int?,comment: String?) {
+        self.rating = rating
+        self.comment = comment
+    }
+}

--- a/lib/src/models/feedback.dart
+++ b/lib/src/models/feedback.dart
@@ -1,0 +1,12 @@
+/// This class contains rating and comment from the user when navigation ends on iOS
+class MapBoxFeedback {
+  int? rating;
+  String? comment;
+
+  MapBoxFeedback({this.rating, this.comment});
+
+  MapBoxFeedback.fromJson(Map<String, dynamic> json) {
+    rating = json['rating'];
+    comment = json['comment'];
+  }
+}

--- a/lib/src/models/models.dart
+++ b/lib/src/models/models.dart
@@ -1,10 +1,11 @@
 export 'event_data.dart';
 export 'events.dart';
+export 'feedback.dart';
+export 'navmode.dart';
 export 'options.dart';
 export 'route_event.dart';
 export 'route_leg.dart';
 export 'route_progress_event.dart';
 export 'route_step.dart';
-export 'way_point.dart';
-export 'navmode.dart';
 export 'voice_units.dart';
+export 'way_point.dart';

--- a/lib/src/models/route_event.dart
+++ b/lib/src/models/route_event.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'events.dart';
-import 'route_progress_event.dart';
+
+import 'package:flutter_mapbox_navigation/flutter_mapbox_navigation.dart';
 
 /// Represents an event sent by the navigation service
 class RouteEvent {
@@ -10,21 +10,21 @@ class RouteEvent {
   RouteEvent({this.eventType, this.data});
 
   RouteEvent.fromJson(Map<String, dynamic> json) {
-    if (json['eventType'] is int) {
-      eventType = MapBoxEvent.values[json['eventType']];
-    } else {
-      try {
-        eventType = MapBoxEvent.values.firstWhere(
-            (e) => e.toString().split(".").last == json['eventType']);
-      } on StateError {
-        //When the list is empty or eventType not found (Bad State: No Element)
-      } catch (e) {
-        // TODO handle the error
-      }
+    try {
+      eventType = MapBoxEvent.values
+          .firstWhere((e) => e.toString().split(".").last == json['eventType']);
+    } on StateError {
+      //When the list is empty or eventType not found (Bad State: No Element)
+    } catch (e) {
+      // TODO handle the error
     }
-    var dataJson = json['data'];
+
+    final dataJson = json['data'];
     if (eventType == MapBoxEvent.progress_change) {
       data = RouteProgressEvent.fromJson(dataJson);
+    } else if (eventType == MapBoxEvent.navigation_finished &&
+        (dataJson as String).isNotEmpty) {
+      data = MapBoxFeedback.fromJson(jsonDecode(dataJson));
     } else {
       data = jsonEncode(dataJson);
     }


### PR DESCRIPTION
Referring to [this](https://github.com/eopeter/flutter_mapbox_navigation/issues/233) and [this](https://github.com/eopeter/flutter_mapbox_navigation/issues/229)

On iOS, event handling is fixed, now uses enums string instead of int so we can properly get on Dart side instead of relying on index. 
When a user ends navigation we get navigation_finished events and also we can collect feedback (rating and comment) in Dart.

On Android, creating a custom InfoPanelEndNavButton (with the same UI) let us override the onTap action, I set it to stop the navigation and send back to dart the navigation_cancelled events.