### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.eopeter.fluttermapboxnavigation'
     compileSdkVersion 33
 
     sourceSets {


### PR DESCRIPTION
Resolve this for android: 

`com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file: /Users/bryanrahmani/.pub-cache/hosted/pub.dev/flutter_mapbox_navigation-0.2.2/android/build.gradle. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.`
   
   
 