### PR TITLE
Specify export behavior on runtime-registered broadcasts for android 14

### DIFF
--- a/android/src/main/kotlin/com/eopeter/fluttermapboxnavigation/activity/NavigationActivity.kt
+++ b/android/src/main/kotlin/com/eopeter/fluttermapboxnavigation/activity/NavigationActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 
 import org.json.JSONObject
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.eopeter.fluttermapboxnavigation.FlutterMapboxNavigationPlugin
 import com.eopeter.fluttermapboxnavigation.R
 import com.eopeter.fluttermapboxnavigation.databinding.NavigationActivityBinding
@@ -148,12 +149,14 @@ class NavigationActivity : AppCompatActivity() {
 
         registerReceiver(
             finishBroadcastReceiver,
-            IntentFilter(NavigationLauncher.KEY_STOP_NAVIGATION)
+            IntentFilter(NavigationLauncher.KEY_STOP_NAVIGATION),
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
 
         registerReceiver(
             addWayPointsBroadcastReceiver,
-            IntentFilter(NavigationLauncher.KEY_ADD_WAYPOINTS)
+            IntentFilter(NavigationLauncher.KEY_ADD_WAYPOINTS),
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
 
         // TODO set the style Uri


### PR DESCRIPTION
For Android 14 and later, the export behavior of runtime-registered broadcasts must be specified, as described in the [Android documentation](https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported).

Without this implementation, the system will throw a SecurityException.

This pull request specifies the export behavior following the guidelines provided by the [Android Developer Guide](https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers).

Thank you in advance for taking the time to review this PR. Your feedback is greatly appreciated!