### PR TITLE
Fix iOS user_off_route event detection

### DIFF
--- a/ios/Classes/NavigationFactory.swift
+++ b/ios/Classes/NavigationFactory.swift
@@ -439,6 +439,10 @@ extension NavigationFactory : NavigationViewControllerDelegate {
         return _shouldReRoute
     }
     
+    public func navigationViewController(_ navigationViewController: NavigationViewController, didRerouteFrom location: CLLocation) {
+        sendEvent(eventType: MapBoxEventType.user_off_route)
+    }
+    
     public func navigationViewController(_ navigationViewController: NavigationViewController, didSubmitArrivalFeedback feedback: EndOfRouteFeedback) {
         
         if(_eventSink != nil)


### PR DESCRIPTION
- Add missing navigationViewController didRerouteFrom delegate method
- Ensures iOS behavior matches Android off-route detection
- Fixes issue where user_off_route event was not triggered on iOS

Fixes #405